### PR TITLE
Resolve InvalidStateError in Internet Explorer when running on localhost

### DIFF
--- a/lib/openpay.v1.js
+++ b/lib/openpay.v1.js
@@ -180,7 +180,7 @@
                         try {
                             _success({
                                 data: JSON.parse(_rhr.responseText),
-                                status: 200,
+                                status: 200
                             });
                         } catch (e) {
                             handleError('Response error (Unknown final status)', _rhr.status, '{}');


### PR DESCRIPTION
This resolves #1 and a trailing comma issue that would also affect IE.

See also the XMLHttpRequest spec: http://xhr.spec.whatwg.org/#the-withcredentials-attribute

I am not sure which minifier you are using, so you can either minify after merging this request, or I can perform minification if you can provider details on how you prefer the file to be minified.
